### PR TITLE
update travis, add pre-commit, add black, force rasterio 1.0...

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+
+repos:
+    -
+        repo: 'https://github.com/ambv/black'
+        # 18.6b1
+        rev: ed50737290662f6ef4016a7ea44da78ee1eff1e2
+        hooks:
+            - id: black
+              args: ['--safe']
+              language_version: python3.6
+    -
+        repo: 'https://github.com/pre-commit/pre-commit-hooks'
+        # v1.3.0
+        rev: a6209d8d4f97a09b61855ea3f1fb250f55147b8b
+        hooks:
+            - id: flake8
+              language_version: python3.6
+              args: [
+                  # E501 let black handle all line length decisions
+                  # W503 black conflicts with "line break before operator" rule
+                  # E203 black conflicts with "whitespace before ':'" rule
+                  '--ignore=E501,W503,E203']
+    -
+        repo: 'https://github.com/chewse/pre-commit-mirrors-pydocstyle'
+        # 2.1.1
+        rev: 22d3ccf6cf91ffce3b16caa946c155778f0cb20f
+        hooks:
+            - id: pydocstyle
+              language_version: python3.6
+              args: [
+                 # Check for docstring presence only
+                 '--select=D1',
+                 # Don't require docstrings for tests
+                 '--match=(?!test).*\.py']

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,36 +3,30 @@ sudo: false
 cache:
   directories:
     - ~/.cache/pip
-env:
-  global:
-    - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
-    - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
-addons:
-  apt:
-    packages:
-    - libgdal1h
-    - gdal-bin
-    - libgdal-dev
-    - libatlas-dev
-    - libatlas-base-dev
-    - gfortran
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-before_install:
-  - "pip install -U pip"
-  - "pip install wheel"
-install:
-  - "pip wheel numpy"
-  - "pip install --use-wheel numpy"
-  - "pip wheel -r requirements.txt"
-  - "pip install --use-wheel -r requirements.txt"
-  - "pip wheel -r requirements-dev.txt"
-  - "pip install --use-wheel -r requirements-dev.txt"
-  - "pip install -e .[test]"
-script:
-  - py.test --cov rio_rgbify --cov-report term-missing
-after_success:
-  - coveralls
 
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+     env: TOXENV=py37
+
+before_install:
+  - python -m pip install -U pip
+install:
+  - python -m pip install codecov pre-commit tox
+script:
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pre-commit run --all-files; fi
+  - tox
+after_success:
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then coverage xml; codecov; fi
+# deploy:
+#   on:
+#     repo: mapbox/rio-rgbify
+#     python: 3.6
+#     tags: true
+#   provider: pypi
+#   distributions: "sdist bdist_wheel"
+#   user: mapboxci

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+comment: off
+
+coverage:
+    status:
+        project:
+            default:
+                target: auto
+                threshold: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-rasterio
+rasterio~=1.0
 Pillow
 rio-mucho>=0.2.1
 mercantile

--- a/rio_rgbify/encoders.py
+++ b/rio_rgbify/encoders.py
@@ -1,8 +1,9 @@
 from __future__ import division
 import numpy as np
 
+
 def data_to_rgb(data, baseval, interval):
-    '''
+    """
     Given an arbitrary (rows x cols) ndarray,
     encode the data into uint8 RGB from an arbitrary
     base and interval
@@ -22,7 +23,7 @@ def data_to_rgb(data, baseval, interval):
     ndarray: rgb data
         a uint8 (3 x rows x cols) ndarray with the
         data encoded
-    '''
+    """
     data = data.astype(np.float64)
     data -= baseval
     data /= interval
@@ -32,31 +33,29 @@ def data_to_rgb(data, baseval, interval):
     datarange = data.max() - data.min()
 
     if _range_check(datarange):
-        raise ValueError('Data of {} larger than 256 ** 3'.format(datarange))
+        raise ValueError("Data of {} larger than 256 ** 3".format(datarange))
 
     rgb = np.zeros((3, rows, cols), dtype=np.uint8)
 
-    rgb[2] = (((data / 256) - (data // 256)) * 256)
-    rgb[1] = ((((data // 256) / 256) - ((data // 256) // 256)) * 256)
-    rgb[0] = (((((data // 256) // 256) / 256) - (((data // 256) // 256) // 256)) * 256)
+    rgb[2] = ((data / 256) - (data // 256)) * 256
+    rgb[1] = (((data // 256) / 256) - ((data // 256) // 256)) * 256
+    rgb[0] = ((((data // 256) // 256) / 256) - (((data // 256) // 256) // 256)) * 256
 
     return rgb
 
 
 def _decode(data, base, interval):
-    '''
+    """
     Utility to decode RGB encoded data
-    '''
+    """
     data = data.astype(np.float64)
     return base + (((data[0] * 256 * 256) + (data[1] * 256) + data[2]) * interval)
 
 
 def _range_check(datarange):
-    '''
+    """
     Utility to check if data range is outside of precision for 3 digit base 256
-    '''
+    """
     maxrange = 256 ** 3
 
     return datarange > maxrange
-
-

--- a/rio_rgbify/scripts/__init__.py
+++ b/rio_rgbify/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""rio-rgbify cli."""

--- a/rio_rgbify/scripts/cli.py
+++ b/rio_rgbify/scripts/cli.py
@@ -9,79 +9,122 @@ from rasterio.rio.options import creation_options
 from rio_rgbify.encoders import data_to_rgb
 from rio_rgbify.mbtiler import RGBTiler
 
-def _rgb_worker(data, window, ij, g_args):
-    return data_to_rgb(data[0][g_args['bidx'] - 1],
-        g_args['base_val'],
-        g_args['interval'])
 
-@click.command('rgbify')
-@click.argument('src_path', type=click.Path(exists=True))
-@click.argument('dst_path', type=click.Path(exists=False))
-@click.option('--base-val', '-b', type=float, default=0,
-    help='The base value of which to base the output encoding on [DEFAULT=0]')
-@click.option('--interval', '-i', type=float, default=1,
-    help='Describes the precision of the output, by incrementing interval [DEFAULT=1]')
-@click.option('--bidx', type=int, default=1,
-    help='Band to encode [DEFAULT=1]')
-@click.option('--max-z', type=int, default=None,
-    help="Maximum zoom to tile (.mbtiles output only)")
-@click.option('--bounding-tile', type=str, default=None,
-    help="Bounding tile '[{x}, {y}, {z}]' to limit output tiles (.mbtiles output only)")
-@click.option('--min-z', type=int, default=None,
-    help="Minimum zoom to tile (.mbtiles output only)")
-@click.option('--format', type=click.Choice(['png', 'webp']), default='png',
-    help="Output tile format (.mbtiles output only)")
-@click.option('--workers', '-j', type=int, default=4,
-    help='Workers to run [DEFAULT=4]')
-@click.option('--verbose', '-v', is_flag=True, default=False)
+def _rgb_worker(data, window, ij, g_args):
+    return data_to_rgb(
+        data[0][g_args["bidx"] - 1], g_args["base_val"], g_args["interval"]
+    )
+
+
+@click.command("rgbify")
+@click.argument("src_path", type=click.Path(exists=True))
+@click.argument("dst_path", type=click.Path(exists=False))
+@click.option(
+    "--base-val",
+    "-b",
+    type=float,
+    default=0,
+    help="The base value of which to base the output encoding on [DEFAULT=0]",
+)
+@click.option(
+    "--interval",
+    "-i",
+    type=float,
+    default=1,
+    help="Describes the precision of the output, by incrementing interval [DEFAULT=1]",
+)
+@click.option("--bidx", type=int, default=1, help="Band to encode [DEFAULT=1]")
+@click.option(
+    "--max-z",
+    type=int,
+    default=None,
+    help="Maximum zoom to tile (.mbtiles output only)",
+)
+@click.option(
+    "--bounding-tile",
+    type=str,
+    default=None,
+    help="Bounding tile '[{x}, {y}, {z}]' to limit output tiles (.mbtiles output only)",
+)
+@click.option(
+    "--min-z",
+    type=int,
+    default=None,
+    help="Minimum zoom to tile (.mbtiles output only)",
+)
+@click.option(
+    "--format",
+    type=click.Choice(["png", "webp"]),
+    default="png",
+    help="Output tile format (.mbtiles output only)",
+)
+@click.option("--workers", "-j", type=int, default=4, help="Workers to run [DEFAULT=4]")
+@click.option("--verbose", "-v", is_flag=True, default=False)
 @click.pass_context
 @creation_options
-def rgbify(ctx, src_path, dst_path, base_val, interval, bidx, max_z, min_z, bounding_tile, format, workers, verbose, creation_options):
-    if dst_path.split('.')[-1].lower() == 'tif':
+def rgbify(
+    ctx,
+    src_path,
+    dst_path,
+    base_val,
+    interval,
+    bidx,
+    max_z,
+    min_z,
+    bounding_tile,
+    format,
+    workers,
+    verbose,
+    creation_options,
+):
+    if dst_path.split(".")[-1].lower() == "tif":
         with rio.open(src_path) as src:
             meta = src.profile.copy()
 
-        meta.update(
-            count=3,
-            dtype=np.uint8
-        )
+        meta.update(count=3, dtype=np.uint8)
 
         for c in creation_options:
             meta[c] = creation_options[c]
 
-        gargs = {
-            'interval': interval,
-            'base_val': base_val,
-            'bidx': bidx
-        }
+        gargs = {"interval": interval, "base_val": base_val, "bidx": bidx}
 
-        with RioMucho([src_path], dst_path, _rgb_worker,
-            options=meta,
-            global_args=gargs) as rm:
+        with RioMucho(
+            [src_path], dst_path, _rgb_worker, options=meta, global_args=gargs
+        ) as rm:
 
             rm.run(workers)
 
-    elif dst_path.split('.')[-1].lower() == 'mbtiles':
+    elif dst_path.split(".")[-1].lower() == "mbtiles":
         if min_z == None or max_z == None:
-            raise ValueError('Zoom range must be provided for mbtile output')
+            raise ValueError("Zoom range must be provided for mbtile output")
 
         if max_z < min_z:
-            raise ValueError('Max zoom {0} must be greater than min zoom {1}'.format(max_z, min_z))
+            raise ValueError(
+                "Max zoom {0} must be greater than min zoom {1}".format(max_z, min_z)
+            )
 
         if bounding_tile is not None:
             try:
                 bounding_tile = json.loads(bounding_tile)
             except:
-                raise TypeError("Bounding tile of {0} is not valid".format(bounding_tile))
+                raise TypeError(
+                    "Bounding tile of {0} is not valid".format(bounding_tile)
+                )
 
-        with RGBTiler(src_path, dst_path,
-                      interval=interval,
-                      base_val=base_val,
-                      format=format,
-                      bounding_tile=bounding_tile,
-                      max_z=max_z, min_z=min_z) as tiler:
+        with RGBTiler(
+            src_path,
+            dst_path,
+            interval=interval,
+            base_val=base_val,
+            format=format,
+            bounding_tile=bounding_tile,
+            max_z=max_z,
+            min_z=min_z,
+        ) as tiler:
 
             tiler.run(workers)
 
     else:
-        raise ValueError('{} output filetype not supported'.format(dst_path.split('.')[-1]))
+        raise ValueError(
+            "{} output filetype not supported".format(dst_path.split(".")[-1])
+        )

--- a/rio_rgbify/scripts/cli.py
+++ b/rio_rgbify/scripts/cli.py
@@ -1,3 +1,5 @@
+"""rio_rgbify CLI."""
+
 import click
 
 import rasterio as rio
@@ -77,6 +79,7 @@ def rgbify(
     verbose,
     creation_options,
 ):
+    """rio-rgbify cli."""
     if dst_path.split(".")[-1].lower() == "tif":
         with rio.open(src_path) as src:
             meta = src.profile.copy()
@@ -95,7 +98,7 @@ def rgbify(
             rm.run(workers)
 
     elif dst_path.split(".")[-1].lower() == "mbtiles":
-        if min_z == None or max_z == None:
+        if min_z is None or max_z is None:
             raise ValueError("Zoom range must be provided for mbtile output")
 
         if max_z < min_z:
@@ -106,7 +109,7 @@ def rgbify(
         if bounding_tile is not None:
             try:
                 bounding_tile = json.loads(bounding_tile)
-            except:
+            except Exception:
                 raise TypeError(
                     "Bounding tile of {0} is not valid".format(bounding_tile)
                 )
@@ -121,7 +124,6 @@ def rgbify(
             max_z=max_z,
             min_z=min_z,
         ) as tiler:
-
             tiler.run(workers)
 
     else:

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 """rio-rgbify: setup."""
 
-import os
 from setuptools import setup, find_packages
 
 # Parse the version from the fiona module.
-with open('rio_rgbify/__init__.py') as f:
+with open("rio_rgbify/__init__.py") as f:
     for line in f:
         if line.find("__version__") >= 0:
             version = line.split("=")[1].strip()
@@ -14,27 +13,31 @@ with open('rio_rgbify/__init__.py') as f:
 
 long_description = """"""
 
+# Runtime requirements.
+inst_reqs = ["click", "rasterio~=1.0", "rio-mucho", "Pillow", "mercantile"]
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+extra_reqs = {
+    "test": ["pytest", "pytest-cov", "codecov", "hypothesis", "raster_tester"],
+    "dev": [
+        "pytest", "pytest-cov", "codecov", "hypothesis", "raster_tester", "pre-commit"
+    ],
+}
 
-
-setup(name='rio-rgbify',
+setup(name="rio-rgbify",
       version=version,
       description=u"Encode arbitrary bit depth rasters in psuedo base-256 as RGB",
       long_description=long_description,
       classifiers=[],
-      keywords='',
+      keywords="",
       author=u"Damon Burgett",
-      author_email='damon@mapbox.com',
-      url='https://github.com/mapbox/rio-rgbify',
-      license='BSD',
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+      author_email="damon@mapbox.com",
+      url="https://github.com/mapbox/rio-rgbify",
+      license="BSD",
+      packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
       include_package_data=True,
       zip_safe=False,
-      install_requires=["click", "rasterio", "rio-mucho", 'Pillow', 'mercantile'],
-      extras_require={
-          'test': ['pytest', 'pytest-cov', 'codecov', 'hypothesis', 'raster_tester']},
+      install_requires=inst_reqs,
+      extras_require=extra_reqs,
       entry_points="""
       [rasterio.rio_plugins]
       rgbify=rio_rgbify.scripts.cli:rgbify

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,8 +11,8 @@ from rio_rgbify.scripts.cli import rgbify
 from raster_tester.compare import affaux, upsample_array
 
 
-in_elev_src = os.path.join(os.path.dirname(__file__), 'fixtures', 'elev.tif')
-expected_src = os.path.join(os.path.dirname(__file__), 'expected', 'elev-rgb.tif')
+in_elev_src = os.path.join(os.path.dirname(__file__), "fixtures", "elev.tif")
+expected_src = os.path.join(os.path.dirname(__file__), "expected", "elev-rgb.tif")
 
 
 def flex_compare(r1, r2, thresh=10):
@@ -24,8 +24,12 @@ def flex_compare(r1, r2, thresh=10):
     r2 = upsample_array(r2, upsample, frAff, toAff)
     tdiff = np.abs(r1.astype(np.float64) - r2.astype(np.float64))
 
-    click.echo('{0} values exceed the threshold difference with a max variance of {1}'.format(
-        np.sum(tdiff > thresh), tdiff.max()), err=True)
+    click.echo(
+        "{0} values exceed the threshold difference with a max variance of {1}".format(
+            np.sum(tdiff > thresh), tdiff.max()
+        ),
+        err=True,
+    )
 
     return not np.any(tdiff > thresh)
 
@@ -33,11 +37,14 @@ def flex_compare(r1, r2, thresh=10):
 def test_cli_good_elev():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(rgbify, [in_elev_src, 'rgb.tif', '--interval', 0.001, '--base-val', -100, '-j', 1])
+        result = runner.invoke(
+            rgbify,
+            [in_elev_src, "rgb.tif", "--interval", 0.001, "--base-val", -100, "-j", 1],
+        )
 
         assert result.exit_code == 0
 
-        with rio.open('rgb.tif') as created:
+        with rio.open("rgb.tif") as created:
             with rio.open(expected_src) as expected:
                 carr = created.read()
                 earr = expected.read()
@@ -48,22 +55,62 @@ def test_cli_good_elev():
 def test_cli_fail_elev():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(rgbify, [in_elev_src, 'rgb.tif', '--interval', 0.00000001, '--base-val', -100, '-j', 1])
-        assert result.exit_code == -1
+        result = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                "rgb.tif",
+                "--interval",
+                0.00000001,
+                "--base-val",
+                -100,
+                "-j",
+                1,
+            ],
+        )
+        assert result.exit_code == 1
+        assert result.exception
 
 
 def test_mbtiler_webp():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        out_mbtiles_finer = 'output-0-dot-1.mbtiles'
-        result_finer = runner.invoke(rgbify, [in_elev_src, out_mbtiles_finer,
-                                              '--interval', 0.1, '--min-z', 10, '--max-z', 11,
-                                              '--format', 'webp', '-j', 1])
+        out_mbtiles_finer = "output-0-dot-1.mbtiles"
+        result_finer = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles_finer,
+                "--interval",
+                0.1,
+                "--min-z",
+                10,
+                "--max-z",
+                11,
+                "--format",
+                "webp",
+                "-j",
+                1,
+            ],
+        )
         assert result_finer.exit_code == 0
 
-        out_mbtiles_coarser = 'output-1.mbtiles'
-        result_coarser = runner.invoke(rgbify, [in_elev_src, out_mbtiles_coarser,
-                                                '--min-z', 10, '--max-z', 11, '--format', 'webp', '-j', 1])
+        out_mbtiles_coarser = "output-1.mbtiles"
+        result_coarser = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles_coarser,
+                "--min-z",
+                10,
+                "--max-z",
+                11,
+                "--format",
+                "webp",
+                "-j",
+                1,
+            ],
+        )
         assert result_coarser.exit_code == 0
 
         assert os.path.getsize(out_mbtiles_finer) > os.path.getsize(out_mbtiles_coarser)
@@ -72,14 +119,40 @@ def test_mbtiler_webp():
 def test_mbtiler_png():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        out_mbtiles_finer = 'output-0-dot-1.mbtiles'
-        result_finer = runner.invoke(rgbify, [in_elev_src, out_mbtiles_finer,
-                                              '--interval', 0.1, '--min-z', 10, '--max-z', 11, '--format', 'png'])
+        out_mbtiles_finer = "output-0-dot-1.mbtiles"
+        result_finer = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles_finer,
+                "--interval",
+                0.1,
+                "--min-z",
+                10,
+                "--max-z",
+                11,
+                "--format",
+                "png",
+            ],
+        )
         assert result_finer.exit_code == 0
 
-        out_mbtiles_coarser = 'output-1.mbtiles'
-        result_coarser = runner.invoke(rgbify, [in_elev_src, out_mbtiles_coarser,
-                                                '--min-z', 10, '--max-z', 11, '--format', 'png', '-j', 1])
+        out_mbtiles_coarser = "output-1.mbtiles"
+        result_coarser = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles_coarser,
+                "--min-z",
+                10,
+                "--max-z",
+                11,
+                "--format",
+                "png",
+                "-j",
+                1,
+            ],
+        )
         assert result_coarser.exit_code == 0
 
         assert os.path.getsize(out_mbtiles_finer) > os.path.getsize(out_mbtiles_coarser)
@@ -88,49 +161,150 @@ def test_mbtiler_png():
 def test_mbtiler_png_bounding_tile():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        out_mbtiles_not_limited = 'output-not-limited.mbtiles'
-        result_not_limited = runner.invoke(rgbify, [in_elev_src, out_mbtiles_not_limited,
-                                                    '--min-z', 12, '--max-z', 12, '--format', 'png'])
+        out_mbtiles_not_limited = "output-not-limited.mbtiles"
+        result_not_limited = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles_not_limited,
+                "--min-z",
+                12,
+                "--max-z",
+                12,
+                "--format",
+                "png",
+            ],
+        )
         assert result_not_limited.exit_code == 0
 
-        out_mbtiles_limited = 'output-limited.mbtiles'
-        result_limited = runner.invoke(rgbify, [in_elev_src, out_mbtiles_limited,
-                                                '--min-z', 12, '--max-z', 12, '--format', 'png',
-                                                '--bounding-tile', '[654, 1582, 12]'])
+        out_mbtiles_limited = "output-limited.mbtiles"
+        result_limited = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles_limited,
+                "--min-z",
+                12,
+                "--max-z",
+                12,
+                "--format",
+                "png",
+                "--bounding-tile",
+                "[654, 1582, 12]",
+            ],
+        )
         assert result_limited.exit_code == 0
 
-        assert os.path.getsize(out_mbtiles_not_limited) > os.path.getsize(out_mbtiles_limited)
+        assert os.path.getsize(out_mbtiles_not_limited) > os.path.getsize(
+            out_mbtiles_limited
+        )
+
+        result_badtile = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles_limited,
+                "--min-z",
+                12,
+                "--max-z",
+                12,
+                "--format",
+                "png",
+                "--bounding-tile",
+                "654-1582-12",
+            ],
+        )
+        assert result_badtile.exit_code == 1
+        assert "is not valid" in str(result_badtile.exception)
 
 
 def test_mbtiler_webp_badzoom():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        out_mbtiles = 'output.mbtiles'
-        result = runner.invoke(rgbify, [in_elev_src, out_mbtiles, '--min-z', 10, '--max-z', 9, '--format', 'webp', '-j', 1])
-        assert result.exit_code == -1
+        out_mbtiles = "output.mbtiles"
+        result = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles,
+                "--min-z",
+                10,
+                "--max-z",
+                9,
+                "--format",
+                "webp",
+                "-j",
+                1,
+            ],
+        )
+        assert result.exit_code == 1
+        assert result.exception
 
 
 def test_mbtiler_webp_badboundingtile():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        out_mbtiles = 'output.mbtiles'
-        result = runner.invoke(rgbify, [in_elev_src, out_mbtiles,
-                                        '--min-z', 10, '--max-z', 9, '--format', 'webp', '--bounding-tile', '654, 1582, 12'])
-        assert result.exit_code == -1
+        out_mbtiles = "output.mbtiles"
+        result = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles,
+                "--min-z",
+                10,
+                "--max-z",
+                9,
+                "--format",
+                "webp",
+                "--bounding-tile",
+                "654, 1582, 12",
+            ],
+        )
+        assert result.exit_code == 1
+        assert result.exception
 
 
 def test_mbtiler_webp_badboundingtile_values():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        out_mbtiles = 'output.mbtiles'
-        result = runner.invoke(rgbify, [in_elev_src, out_mbtiles,
-                                        '--min-z', 10, '--max-z', 9, '--format', 'webp', '--bounding-tile', '[654, 1582]'])
-        assert result.exit_code == -1
+        out_mbtiles = "output.mbtiles"
+        result = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles,
+                "--min-z",
+                10,
+                "--max-z",
+                9,
+                "--format",
+                "webp",
+                "--bounding-tile",
+                "[654, 1582]",
+            ],
+        )
+        assert result.exit_code == 1
+        assert result.exception
 
 
 def test_bad_input_format():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        out_mbtiles = 'output.lol'
-        result = runner.invoke(rgbify, [in_elev_src, out_mbtiles, '--min-z', 10, '--max-z', 9, '--format', 'webp', '-j', 1])
-        assert result.exit_code == -1
+        out_mbtiles = "output.lol"
+        result = runner.invoke(
+            rgbify,
+            [
+                in_elev_src,
+                out_mbtiles,
+                "--min-z",
+                10,
+                "--max-z",
+                9,
+                "--format",
+                "webp",
+                "-j",
+                1,
+            ],
+        )
+        assert result.exit_code == 1
+        assert result.exception

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py37,py36,py27
+
+
+[testenv]
+extras = test
+commands=
+    python -m pytest --cov rio_rgbify --cov-report term-missing --ignore=venv
+deps=
+    numpy


### PR DESCRIPTION
This PR does: 
- update travis.yaml (copy form rio-glui)
- add black (as for other rio/mapbox python project) 
- add pre-commit
- switch to rasterio 1.0 

The only code change has been done to accommodate black/flake8 

Right now tests are falling with because of different error code returned by click 

```
    def test_mbtiler_webp_badzoom():
        runner = CliRunner()
        with runner.isolated_filesystem():
            out_mbtiles = 'output.mbtiles'
            result = runner.invoke(rgbify, [in_elev_src, out_mbtiles, '--min-z', 10, '--max-z', 9, '--format', 'webp', '-j', 1])
>           assert result.exit_code == -1
E           AssertionError: assert 1 == -1
E            +  where 1 = <Result ValueError('Max zoom 9 must be greater than min zoom 10',)>.exit_code
```

cc @dnomadb 