### PR TITLE
Add round-digits option to have better image compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Options:
                          on [DEFAULT=0]
   -i, --interval FLOAT   Describes the precision of the output, by
                          incrementing interval [DEFAULT=1]
+  -r, --round-digits     Less significants encoded bits to be set
+                         to 0. Round the values, but have better
+                         images compression [DEFAULT=0]
   --bidx INTEGER         Band to encode [DEFAULT=1]
   --max-z INTEGER        Maximum zoom to tile (.mbtiles output only)
   --bounding-tile TEXT   Bounding tile '[{x}, {y}, {z}]' to limit output tiles

--- a/rio_rgbify/encoders.py
+++ b/rio_rgbify/encoders.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 
 
-def data_to_rgb(data, baseval, interval):
+def data_to_rgb(data, baseval, interval, round_digits=0):
     """
     Given an arbitrary (rows x cols) ndarray,
     encode the data into uint8 RGB from an arbitrary
@@ -17,6 +17,8 @@ def data_to_rgb(data, baseval, interval):
         will be treated as zero for this encoding
     interval: float
         the interval at which to encode
+    round_digits: int
+        erased less significant digits
 
     Returns
     --------
@@ -27,6 +29,8 @@ def data_to_rgb(data, baseval, interval):
     data = data.astype(np.float64)
     data -= baseval
     data /= interval
+
+    data = np.around(data / 2**round_digits) * 2**round_digits
 
     rows, cols = data.shape
 

--- a/rio_rgbify/mbtiler.py
+++ b/rio_rgbify/mbtiler.py
@@ -103,7 +103,7 @@ def _encode_as_png(data, profile, dst_transform):
 def _tile_worker(tile):
     """
     For each tile, and given an open rasterio src, plus a`global_args` dictionary
-    with attributes of `base_val`, `interval`, and a `writer_func`,
+    with attributes of `base_val`, `interval`, `round_digits` and a `writer_func`,
     warp a continous single band raster to a 512 x 512 mercator tile,
     then encode this tile into RGB.
 
@@ -142,7 +142,7 @@ def _tile_worker(tile):
         resampling=Resampling.bilinear,
     )
 
-    out = data_to_rgb(out, global_args["base_val"], global_args["interval"])
+    out = data_to_rgb(out, global_args["base_val"], global_args["interval"], global_args["round_digits"])
 
     return tile, global_args["writer_func"](out, global_args["kwargs"].copy(), toaffine)
 
@@ -235,6 +235,9 @@ class RGBTiler:
     interval: float
         the interval at which to encode
         Default=1
+    round_digits: int
+        Erased less significant digits
+        Default=0
     format: str
         output tile image format (png or webp)
         Default=png
@@ -255,6 +258,7 @@ class RGBTiler:
         max_z,
         interval=1,
         base_val=0,
+        round_digits=0,
         bounding_tile=None,
         **kwargs
     ):
@@ -291,6 +295,7 @@ class RGBTiler:
             },
             "base_val": base_val,
             "interval": interval,
+            "round_digits": round_digits,
             "writer_func": writer_func,
         }
 

--- a/rio_rgbify/scripts/cli.py
+++ b/rio_rgbify/scripts/cli.py
@@ -14,7 +14,7 @@ from rio_rgbify.mbtiler import RGBTiler
 
 def _rgb_worker(data, window, ij, g_args):
     return data_to_rgb(
-        data[0][g_args["bidx"] - 1], g_args["base_val"], g_args["interval"]
+        data[0][g_args["bidx"] - 1], g_args["base_val"], g_args["interval"], g_args["round_digits"]
     )
 
 
@@ -34,6 +34,13 @@ def _rgb_worker(data, window, ij, g_args):
     type=float,
     default=1,
     help="Describes the precision of the output, by incrementing interval [DEFAULT=1]",
+)
+@click.option(
+    "--round-digits",
+    "-r",
+    type=int,
+    default=0,
+    help="Less significants encoded bits to be set to 0. Round the values, but have better images compression [DEFAULT=0]",
 )
 @click.option("--bidx", type=int, default=1, help="Band to encode [DEFAULT=1]")
 @click.option(
@@ -70,6 +77,7 @@ def rgbify(
     dst_path,
     base_val,
     interval,
+    round_digits,
     bidx,
     max_z,
     min_z,
@@ -89,7 +97,7 @@ def rgbify(
         for c in creation_options:
             meta[c] = creation_options[c]
 
-        gargs = {"interval": interval, "base_val": base_val, "bidx": bidx}
+        gargs = {"interval": interval, "base_val": base_val, "round_digits": round_digits, "bidx": bidx}
 
         with RioMucho(
             [src_path], dst_path, _rgb_worker, options=meta, global_args=gargs
@@ -119,6 +127,7 @@ def rgbify(
             dst_path,
             interval=interval,
             base_val=base_val,
+            round_digits=round_digits,
             format=format,
             bounding_tile=bounding_tile,
             max_z=max_z,

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -15,8 +15,9 @@ def test_encode_data_roundtrip():
 
     baseval = -1000
     interval = 0.1
+    round_digits = 0
 
-    rtripped = _decode(data_to_rgb(testdata.copy(), baseval, interval), baseval, interval)
+    rtripped = _decode(data_to_rgb(testdata.copy(), baseval, interval, round_digits=round_digits), baseval, interval)
 
     assert testdata.min() == rtripped.min()
     assert testdata.max() == rtripped.max()
@@ -28,7 +29,7 @@ def test_encode_failrange():
     testdata[1] = 256 ** 3 + 1
 
     with pytest.raises(ValueError):
-        data_to_rgb(testdata, 0, 1)
+        data_to_rgb(testdata, 0, 1, 0)
 
 
 def test_catch_range():


### PR DESCRIPTION
# In short

Add an option to arbitrary round the encoded elevation value. Switch to 0 an arbitrary number of lower digit to reduce the noise into the RGB encoded image.
Less noise achieves a better compression.
It has the counter part to approximate the encoded elevation.

For low zoom level (like 8) the elevation change between pixel is hight, but the elevation precision required at this overview level is low. We can erase lot of lower digits and have high compression gain.

At upper zoom (like 12), the noise on lower digits is lesser. But we can still save space by round some few lower bits.



# Long version

An original tile of z8. 430 KB.

![rio-rgbify-04-z8-92](https://user-images.githubusercontent.com/1785486/142873977-0b21fb85-844e-42e6-b556-4c4c949a0a46.png)

If we look at the different colors separately of a level 8 tile, we can clearly see that red does not vary, green varies little and blue a lot.

Decomposition of the levels of Red, Green and Blue. Note that the first one is indeed "red", but very dark, uniform value: 1 out of 255.

![rio-rgbify-08-ChannelRGB](https://user-images.githubusercontent.com/1785486/142873683-ddf2da1b-8514-4f22-bcb2-a8ea4fb90975.png)

It can be seen that the Blue channel is much noisier than the others, especially for low zoom levels where the altitude varies a lot from one pixel to its neighbors, almost at random. If we delete the blue channel (we can't really delete it, but set the value to 0 for all pixels) then the same image compressed in PNG is only 91 Kb, or 80% less. Tthis very noisy data that makes the image difficult to compress. The more random the values are, the greater the entropy, and therefore the ineffective compression.

Tile at zoom level 8 containing 0 for the blue value. 97 Kb, or 77% less.

![rio-rgbify-09-z8-92RG](https://user-images.githubusercontent.com/1785486/142873736-15dd91c3-e21a-4593-a05e-319a03835954.png)

Tile with zoom level 12 containing 0 for the blue value. 41 KB, or 87% less.

![rio-rgbify-10-z12-1484RG](https://user-images.githubusercontent.com/1785486/142873796-42997e4a-65cf-451a-b384-f6301186ec21.png)

The blue channel has an amplitude of 256 levels, one level represents 10 cm. We have therefore introduced a maximum error of 256 * 0.1 = 25.6 m in altitude.

For example, at a zoom level of 8, the horizontal difference between two pixels is 431 m, an altimetry error of 25 m may be acceptable.

Animation showing the shading at zoom 8 before and after changing the values stored in the blue to 0. Having trouble seeing the animation? That's a good sign!

![rio-rgbify-11-diff-optim](https://user-images.githubusercontent.com/1785486/142873826-5fd7368a-3099-45d4-87fb-e604a4bce688.gif)

The same area with an extract enlarged x4 to see better what's going on.

![rio-rgbify-12-diff-optim_x4](https://user-images.githubusercontent.com/1785486/142873855-8575080e-85d2-4762-aa5a-edadfb440760.gif)

Differences in shading values before and after modification.

![rio-rgbify-13-diff](https://user-images.githubusercontent.com/1785486/142873880-b4971932-cf43-4fe6-a9fb-5a2ee4e21a8c.png)

Removing the blue-encoded part is in fact equivalent to rounding the altitude to the nearest 25 m and setting the last 8 bits (the bits encoded in blue) to 0. This can be extended by varying the level of precision on which the altitude is rounded and therefore the number of last bits that are set to 0 depending on the zoom level.

The processing of the French DEM at horizon precision of 25m to z5 up to z12 produce an 1.3 GB in PNG instead of 3.7, which is a 65% reduction in size, and 0.8 GB in WebP instead of 2.2 GB, which is also a 65% reduction in size. Using a ramp of rounding precision from 11 digits à z5 down to 4 digits at z12.
