### PR TITLE
Fix typo "psuedo" -> "pseudo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rio-rgbify
-Encode arbitrary bit depth rasters in psuedo base-256 as RGB
+Encode arbitrary bit depth rasters in pseudo base-256 as RGB
 
 [![Build Status](https://travis-ci.org/mapbox/rio-rgbify.svg)](https://travis-ci.org/mapbox/rio-rgbify)[![Coverage Status](https://coveralls.io/repos/github/mapbox/rio-rgbify/badge.svg?branch=its-a-setup)](https://coveralls.io/github/mapbox/rio-rgbify)
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extra_reqs = {
 
 setup(name="rio-rgbify",
       version=version,
-      description=u"Encode arbitrary bit depth rasters in psuedo base-256 as RGB",
+      description=u"Encode arbitrary bit depth rasters in pseudo base-256 as RGB",
       long_description=long_description,
       classifiers=[],
       keywords="",


### PR DESCRIPTION
The Github project description needs this fix too.