### PR TITLE
Restore compatibility with rasterio >= 1.3

### DIFF
--- a/rio_rgbify/mbtiler.py
+++ b/rio_rgbify/mbtiler.py
@@ -12,7 +12,7 @@ import rasterio
 import numpy as np
 import sqlite3
 from multiprocessing import Pool
-from rasterio._io import virtual_file_to_buffer
+from rasterio.io import MemoryFile
 from riomucho.single_process_pool import MockTub
 
 from io import BytesIO
@@ -90,14 +90,12 @@ def _encode_as_png(data, profile, dst_transform):
     contents: bytearray
         png-encoded bytearray of the provided input data
     """
-    profile["affine"] = dst_transform
+    profile["transform"] = dst_transform
 
-    with rasterio.open("/vsimem/tileimg", "w", **profile) as dst:
-        dst.write(data)
-
-    contents = bytearray(virtual_file_to_buffer("/vsimem/tileimg"))
-
-    return contents
+    with MemoryFile() as memfile:
+        with memfile.open(**profile) as dst:
+            dst.write(data)
+        return bytearray(memfile.read())
 
 
 def _tile_worker(tile):
@@ -192,7 +190,7 @@ def _make_tiles(bbox, src_crs, minz, maxz):
         generator of [x, y, z] tiles that intersect
         the provided bounding box
     """
-    w, s, e, n = transform_bounds(*[src_crs, "EPSG:4326"] + bbox, densify_pts=0)
+    w, s, e, n = transform_bounds(src_crs, "EPSG:4326", *bbox)
 
     EPSILON = 1.0e-10
 

--- a/test/test_mbtiler.py
+++ b/test/test_mbtiler.py
@@ -60,8 +60,6 @@ def test_webp_writer():
 
     test_bytearray = _encode_as_webp(test_data)
 
-    assert len(test_bytearray) == 34
-
     test_complex_data = test_data.copy()
 
     test_complex_data[0] += (np.random.rand(256, 256) * 255).astype(np.uint8)


### PR DESCRIPTION
Fixes #39

## Summary

The mbtiler path no longer ran on current rasterio (tested against 1.4.4). Three API breaks fixed:

- `rasterio._io.virtual_file_to_buffer` was a private API and has been removed. Switched `_encode_as_png` to the public `rasterio.io.MemoryFile`.
- The `affine` profile key was deprecated in rasterio 1.0 in favor of `transform`. It was being silently ignored, so output PNG tiles had no transform set.
- `transform_bounds(..., densify_pts=0)` is now rejected when the destination CRS is geographic (`densify_pts must be at least 2 if the output is geograpic`). Dropped the override; rasterio's default (21) is appropriate here.

Also dropped a brittle `assert len(test_bytearray) == 34` in `test_webp_writer` — the exact webp byte count varies across libwebp / Pillow versions (currently 42 with Pillow 10), and the relative comparison right after it (complex data encodes larger than zero-data) still covers the intent.

## Test plan

- [x] `pytest` — 19/19 pass against `rasterio==1.4.4`, `Pillow==10.x`, Python 3.10
- [x] End-to-end CLI smoke against `test/fixtures/elev.tif`:
  ```
  rio rgbify test/fixtures/elev.tif out.mbtiles \
    --base-val -100 --interval 0.1 \
    --min-z 10 --max-z 13 --format webp -j 4
  ```
  Produces a valid 84 KB mbtiles with tiles at z10–13 (1, 1, 2, 2).